### PR TITLE
Update create.yml to remove ansible warning

### DIFF
--- a/molecule/podman/create.yml
+++ b/molecule/podman/create.yml
@@ -5,7 +5,9 @@
     molecule_inventory:
       all:
         hosts: {}
-        molecule: {}
+        children:
+          molecule:
+            hosts: {}
   tasks:
     - name: Create a container
       containers.podman.podman_container:

--- a/molecule/podman/create.yml
+++ b/molecule/podman/create.yml
@@ -8,6 +8,7 @@
         children:
           molecule:
             hosts: {}
+
   tasks:
     - name: Create a container
       containers.podman.podman_container:


### PR DESCRIPTION
The original molecule_inventory definition generates an ansible runtime warning the the term 'molecule' is not allowed, only hosts and children and vars. 

No ansible runtime warning with this change. Content of temporay molecule_inventory.yml seems correct.